### PR TITLE
Add psycopg2 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ drf-spectacular==0.27.2
 gunicorn==22.0.0
 prometheus_client==0.20.0
 tzdata==2024.1
+psycopg2-binary==2.9.9


### PR DESCRIPTION
Add psycopg2 to requirements for postgresql support to avoid error

```
File "/venv/lib/python3.10/site-packages/django/db/backends/postgresql/base.py", line 29, in <module>                             
raise ImproperlyConfigured("Error loading psycopg2 or psycopg module")                                                          
django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 or psycopg module
```