### PR TITLE
Make API work with opentofu REST module

### DIFF
--- a/coral_credits/api/serializers.py
+++ b/coral_credits/api/serializers.py
@@ -46,7 +46,7 @@ class CreditAllocationResourceSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.CreditAllocationResource
-        fields = ["resource_class", "resource_hours"]
+        fields = ["id", "resource_class", "resource_hours"]
 
     def to_representation(self, instance):
         """Pass the context to the ResourceClassSerializer"""

--- a/coral_credits/api/views.py
+++ b/coral_credits/api/views.py
@@ -114,12 +114,12 @@ class AccountViewSet(viewsets.ModelViewSet):
         )
 
         # TODO(johngarbutt) look for any during the above allocations
-        consumers_query = models.Consumer.objects.filter(account__pk=pk)
+        consumers_query = models.Consumer.objects.filter(resource_provider_account__account__pk=pk)
         consumers = serializers.Consumer(
             consumers_query, many=True, context={"request": request}
         )
 
-        account_summary["allocations"] = allocations.data
+        account_summary["allocations"] = allocations
         account_summary["consumers"] = consumers.data
 
         # add resource_hours_remaining... must be a better way!

--- a/coral_credits/api/views.py
+++ b/coral_credits/api/views.py
@@ -58,6 +58,10 @@ class CreditAllocationResourceViewSet(viewsets.ModelViewSet):
         serializer = serializers.CreditAllocationResourceSerializer(
             updated_allocations, many=True, context={"request": request}
         )
+        # To allow for the allocation resource endpoint to operate as a single REST object
+        # with GET,POST,PATCH etc after creation of single item
+        # When creating with multiple resources a list of multiple entries is returned,
+        # each with their own unique ID
         if len(serializer.data) == 1:
           return Response(serializer.data[0], status=status.HTTP_201_CREATED)
         else:
@@ -108,6 +112,9 @@ class AccountViewSet(viewsets.ModelViewSet):
         account_summary = serializer.data
 
         # TODO(johngarbutt) look for any during the above allocations
+
+        # ISSUE (stuartc) this creates errors if objects are actually found when the account entry
+        # is retrieved. Unable to serialise the list.
         all_allocations_query = models.CreditAllocation.objects.filter(account__pk=pk)
         allocations = serializers.CreditAllocationSerializer(
             all_allocations_query, many=True
@@ -119,7 +126,7 @@ class AccountViewSet(viewsets.ModelViewSet):
             consumers_query, many=True, context={"request": request}
         )
 
-        account_summary["allocations"] = allocations
+        account_summary["allocations"] = allocations.data
         account_summary["consumers"] = consumers.data
 
         # add resource_hours_remaining... must be a better way!

--- a/coral_credits/api/views.py
+++ b/coral_credits/api/views.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 class CreditAllocationViewSet(viewsets.ModelViewSet):
     queryset = models.CreditAllocation.objects.all()
     serializer_class = serializers.CreditAllocationSerializer
-    # permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class CreditAllocationResourceViewSet(viewsets.ModelViewSet):
@@ -58,7 +58,10 @@ class CreditAllocationResourceViewSet(viewsets.ModelViewSet):
         serializer = serializers.CreditAllocationResourceSerializer(
             updated_allocations, many=True, context={"request": request}
         )
-        return _http_200_ok(serializer.data)
+        if len(serializer.data) == 1:
+          return Response(serializer.data[0], status=status.HTTP_201_CREATED)
+        else:
+          return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def _validate_request(self, request):
 

--- a/coral_credits/urls.py
+++ b/coral_credits/urls.py
@@ -24,6 +24,8 @@ from rest_framework_nested import routers
 
 from coral_credits.api import views
 
+# setup to endpoints to support both with and without trailing slashes
+#
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"resource_class", views.ResourceClassViewSet)
 router.register(r"resource_class/", views.ResourceClassViewSet, basename="resourceclassslash")

--- a/coral_credits/urls.py
+++ b/coral_credits/urls.py
@@ -24,20 +24,25 @@ from rest_framework_nested import routers
 
 from coral_credits.api import views
 
-router = routers.DefaultRouter()
+router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"resource_class", views.ResourceClassViewSet)
+router.register(r"resource_class/", views.ResourceClassViewSet, basename="resourceclassslash")
 router.register(r"resource_provider", views.ResourceProviderViewSet)
+router.register(r"resource_provider/", views.ResourceProviderViewSet, basename="resourceproviderslash")
 router.register(r"resource_provider_account", views.ResourceProviderAccountViewSet)
+router.register(r"resource_provider_account/", views.ResourceProviderAccountViewSet, basename="resourceprovideraccountslash")
 router.register(r"allocation", views.CreditAllocationViewSet)
+router.register(r"allocation/", views.CreditAllocationViewSet, basename="allocationslash")
 router.register(r"account", views.AccountViewSet, basename="creditaccount")
+router.register(r"account/", views.AccountViewSet, basename="creditaccountslash")
 router.register(r"consumer", views.ConsumerViewSet, basename="resource-request")
+router.register(r"consumer/", views.ConsumerViewSet, basename="resource-requestslash")
 
 allocation_router = routers.NestedSimpleRouter(
-    router, r"allocation", lookup="allocation"
+    router, r"allocation", lookup="allocation", trailing_slash=False
 )
-allocation_router.register(
-    r"resources", views.CreditAllocationResourceViewSet, basename="allocation-resource"
-)
+allocation_router.register(r"resources", views.CreditAllocationResourceViewSet, basename="allocation-resource")
+allocation_router.register(r"resources/", views.CreditAllocationResourceViewSet, basename="allocation-resource-slash")
 
 
 def prometheus_metrics(request):

--- a/etc/coral-credits/defaults.py
+++ b/etc/coral-credits/defaults.py
@@ -18,7 +18,6 @@ DEBUG = False
 
 # In a Docker container, ALLOWED_HOSTS is always '*' - let the proxy worry about hosts
 ALLOWED_HOSTS = ["*"]
-#CSRF_TRUSTED_ORIGINS = [ "https://credits.apps.10-129-110-40.sslip.io" ]
 
 # Make sure Django interprets the script name correctly if set
 if "SCRIPT_NAME" in os.environ:

--- a/etc/coral-credits/defaults.py
+++ b/etc/coral-credits/defaults.py
@@ -18,7 +18,7 @@ DEBUG = False
 
 # In a Docker container, ALLOWED_HOSTS is always '*' - let the proxy worry about hosts
 ALLOWED_HOSTS = ["*"]
-CSRF_TRUSTED_ORIGINS = [ "https://credits.apps.10-129-110-40.sslip.io" ]
+#CSRF_TRUSTED_ORIGINS = [ "https://credits.apps.10-129-110-40.sslip.io" ]
 
 # Make sure Django interprets the script name correctly if set
 if "SCRIPT_NAME" in os.environ:

--- a/etc/coral-credits/defaults.py
+++ b/etc/coral-credits/defaults.py
@@ -18,6 +18,7 @@ DEBUG = False
 
 # In a Docker container, ALLOWED_HOSTS is always '*' - let the proxy worry about hosts
 ALLOWED_HOSTS = ["*"]
+CSRF_TRUSTED_ORIGINS = [ "https://credits.apps.10-129-110-40.sslip.io" ]
 
 # Make sure Django interprets the script name correctly if set
 if "SCRIPT_NAME" in os.environ:


### PR DESCRIPTION
A few tweaks but the main area that needs work is 
`class CreditAllocationResourceViewSet(viewsets.ModelViewSet):`

This crashes out for any query that should also return resource allocations for the given account. The code looks incomplete and appeated to be using the wrong account field for the search.

Also the allocation resource object was not functioning as a single REST object because the creation was done via the allocation object for multiple entries. Consequently a dumb client (such as TF Rest API) cannot create and manage individual resources. The change I made to make it operate with a single item patches this but it might be better to implement a new endpoint