### PR TITLE
Fix azimuth-cloud actions org

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -24,10 +24,10 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: stackhpc/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@master
 
       - name: Publish Helm charts
-        uses: stackhpc/github-actions/helm-publish@master
+        uses: azimuth-cloud/github-actions/helm-publish@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -38,7 +38,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: coral-credits
           context: .


### PR DESCRIPTION
stackhpc/github-actions was migrated to azimuth-cloud. Fix this so it doens't confuse pinning actions.